### PR TITLE
#97 refactoring: update transactional

### DIFF
--- a/src/main/java/com/example/algoproject/belongsto/service/BelongsToService.java
+++ b/src/main/java/com/example/algoproject/belongsto/service/BelongsToService.java
@@ -23,12 +23,12 @@ public class BelongsToService {
         belongsToRepository.save(belongsTo);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<BelongsTo> findByStudy(Study study) {
         return belongsToRepository.findByStudy(study);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<BelongsTo> findByMember(User user) {
         return belongsToRepository.findByMember(user);
     }

--- a/src/main/java/com/example/algoproject/problem/service/ProblemService.java
+++ b/src/main/java/com/example/algoproject/problem/service/ProblemService.java
@@ -9,16 +9,14 @@ import com.example.algoproject.problem.dto.response.ProblemInfo;
 import com.example.algoproject.problem.repository.ProblemRepository;
 import com.example.algoproject.session.domain.Session;
 import com.example.algoproject.session.service.SessionService;
-import com.example.algoproject.study.domain.Study;
 import com.example.algoproject.study.service.StudyService;
-import com.example.algoproject.user.domain.User;
 import com.example.algoproject.user.dto.CustomUserDetailsVO;
 import com.example.algoproject.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,7 +47,7 @@ public class ProblemService {
         return responseService.getSingleResponse(new ProblemInfo(problem));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CommonResponse list(CustomUserDetailsVO cudVO, Long sessionId) {
 
         Session session = sessionService.findById(sessionId);
@@ -70,7 +68,7 @@ public class ProblemService {
         return responseService.getSuccessResponse();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Problem findById(Long id) {
         return problemRepository.findById(id).orElseThrow(NotExistProblemException::new);
     }

--- a/src/main/java/com/example/algoproject/session/service/SessionService.java
+++ b/src/main/java/com/example/algoproject/session/service/SessionService.java
@@ -44,7 +44,7 @@ public class SessionService {
         return responseService.getSingleResponse(new SessionInfo(session));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CommonResponse list(CustomUserDetailsVO cudVO, String studyId) {
 
         User user = userService.findById(cudVO.getUsername());
@@ -56,7 +56,7 @@ public class SessionService {
         return responseService.getListResponse(getSessionInfos(sessionRepository.findByStudy(study)));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CommonResponse detail(CustomUserDetailsVO cudVO, Long id) {
         Session session = findById(id);
         User user = userService.findById(cudVO.getUsername());
@@ -96,7 +96,7 @@ public class SessionService {
         return responseService.getSuccessResponse();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Session findById(Long id) {
         return sessionRepository.findById(id).orElseThrow(NotExistSessionException::new);
     }

--- a/src/main/java/com/example/algoproject/solution/service/SolutionService.java
+++ b/src/main/java/com/example/algoproject/solution/service/SolutionService.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -51,6 +52,7 @@ public class SolutionService {
     private final ResponseService responseService;
     private final PathUtil pathUtil;
 
+    @Transactional
     public CommonResponse create(CustomUserDetailsVO cudVO, AddSolution addSolution) throws IOException {
 
         User user = userService.findById(cudVO.getUsername());
@@ -87,6 +89,7 @@ public class SolutionService {
         return responseService.getSuccessResponse();
     }
 
+    @Transactional(readOnly = true)
     public CommonResponse detail(CustomUserDetailsVO cudVO, Long solutionId) {
 
         User user = userService.findById(cudVO.getUsername());
@@ -100,6 +103,7 @@ public class SolutionService {
         return responseService.getSingleResponse(new SolutionInfo(solution.getCode(), solution.getReadMe(), solution.getDate(), solution.getReviews()));
     }
 
+    @Transactional(readOnly = true)
     public CommonResponse list(CustomUserDetailsVO cudVO, Long problemId) {
 
         User user = userService.findById(cudVO.getUsername());
@@ -127,6 +131,7 @@ public class SolutionService {
         return responseService.getListResponse(list);
     }
 
+    @Transactional
     public CommonResponse update(CustomUserDetailsVO cudVO, Long solutionId, UpdateSolution updateSolution) throws IOException {
 
         User user = userService.findById(cudVO.getUsername());
@@ -163,6 +168,7 @@ public class SolutionService {
         return responseService.getSuccessResponse();
     }
 
+    @Transactional
     public CommonResponse delete(CustomUserDetailsVO cudVO, Long solutionId) {
 
         User user = userService.findById(cudVO.getUsername());
@@ -217,10 +223,12 @@ public class SolutionService {
         }
     }
 
+    @Transactional(readOnly = true)
     public Solution findById(Long solutionId) {
         return solutionRepository.findById(solutionId).orElseThrow(NotExistSolutionException::new);
     }
 
+    @Transactional(readOnly = true)
     public Optional<Solution> findByPath(String path) {
         Optional<Solution> solutionCode = solutionRepository.findByCodePath(path);
         Optional<Solution> solutionReadMe = solutionRepository.findByReadMePath(path);

--- a/src/main/java/com/example/algoproject/study/service/StudyService.java
+++ b/src/main/java/com/example/algoproject/study/service/StudyService.java
@@ -13,8 +13,6 @@ import com.example.algoproject.errors.exception.notfound.NotExistRepositoryExcep
 import com.example.algoproject.errors.exception.notfound.NotExistStudyException;
 import com.example.algoproject.errors.response.CommonResponse;
 import com.example.algoproject.errors.response.ResponseService;
-import com.example.algoproject.solution.domain.Solution;
-import com.example.algoproject.solution.service.SolutionService;
 import com.example.algoproject.study.domain.Study;
 import com.example.algoproject.study.dto.request.*;
 import com.example.algoproject.study.dto.response.StudyInfo;
@@ -100,7 +98,7 @@ public class StudyService {
         return responseService.getSingleResponse(new StudyInfo(study, getMemberInfos(getMembers(study))));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CommonResponse detail(CustomUserDetailsVO cudVO, String id) {
 
         User user = userService.findById(cudVO.getUsername());
@@ -113,7 +111,7 @@ public class StudyService {
         return responseService.getSingleResponse(new StudyInfo(study, getMemberInfos(members)));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CommonResponse list(CustomUserDetailsVO cudVO) {
         return responseService.getListResponse(getStudyInfos(userService.findById(cudVO.getUsername())));
     }
@@ -192,7 +190,7 @@ public class StudyService {
         return responseService.getSuccessResponse();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CommonResponse searchMember(CustomUserDetailsVO cudVO, SearchUser request) {
 
         log.info("search user name: {}", request.getName());
@@ -254,7 +252,7 @@ public class StudyService {
         studyRepository.save(study);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Study findById(String id) {
         return studyRepository.findById(id).orElseThrow(NotExistStudyException::new);
     }

--- a/src/main/java/com/example/algoproject/user/service/UserService.java
+++ b/src/main/java/com/example/algoproject/user/service/UserService.java
@@ -63,17 +63,17 @@ public class UserService {
         return responseService.getSingleResponse(new LoginDto(jwtUtil.makeJWT(userInfoResponse.get("id").toString()), userInfoResponse.get("login").toString()));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public User findById(String id) {
         return userRepository.findById(id).orElseThrow(NotExistUserException::new);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public User findByName(String name) {
         return userRepository.findByName(name).orElseThrow(NotExistUserException::new);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<User> findByNameContains(String name) {
         return userRepository.findByNameContains(name);
     }


### PR DESCRIPTION
- 단순 조히만 하는 @transactional 어노테이션은 (readOnly = true) 옵션을 추가하도록 변경
    - 예상치 못한 엔터티의 변경 or 삭제를 예방
    - 엔터티를 읽기 전용으로 조회하면 변경 감지를 위한 스냅샷을 유지하지 않아도 되고, 영속성 컨텍스트를 플러시하지 않아도 되기 때문에 성능을 최적화