### PR TITLE
Feat/155

### DIFF
--- a/src/main/java/com/example/algoproject/belongsto/domain/BelongsTo.java
+++ b/src/main/java/com/example/algoproject/belongsto/domain/BelongsTo.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 public class BelongsTo {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/example/algoproject/contain/domain/Contain.java
+++ b/src/main/java/com/example/algoproject/contain/domain/Contain.java
@@ -1,0 +1,42 @@
+package com.example.algoproject.contain.domain;
+
+import com.example.algoproject.problem.domain.Problem;
+import com.example.algoproject.session.domain.Session;
+import com.example.algoproject.solution.domain.Solution;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Contain {
+
+    @Id
+    @Column(name = "contatin_id")
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "session_id")
+    private Session session;
+
+    @ManyToOne
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+
+    @OneToMany(
+            mappedBy = "contain",
+            cascade = {CascadeType.ALL},
+            orphanRemoval = true
+    )
+    private List<Solution> solutions = new ArrayList<>();
+
+    public Contain(Session session, Problem problem) {
+        this.session = session;
+        this.problem = problem;
+    }
+}

--- a/src/main/java/com/example/algoproject/contain/domain/Contain.java
+++ b/src/main/java/com/example/algoproject/contain/domain/Contain.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class Contain {
 
     @Id
-    @Column(name = "contatin_id")
+    @Column(name = "contain_id")
     @GeneratedValue
     private Long id;
 

--- a/src/main/java/com/example/algoproject/contain/repository/ContainRepository.java
+++ b/src/main/java/com/example/algoproject/contain/repository/ContainRepository.java
@@ -1,0 +1,18 @@
+package com.example.algoproject.contain.repository;
+
+import com.example.algoproject.contain.domain.Contain;
+import com.example.algoproject.problem.domain.Problem;
+import com.example.algoproject.session.domain.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ContainRepository extends JpaRepository<Contain, Long> {
+    List<Contain> findBySession(Session session);
+
+    void deleteAllBySession(Session session);
+
+    Contain findBySessionAndProblem(Session session, Problem problem);
+
+    void deleteBySessionAndProblem(Session session, Problem problem);
+}

--- a/src/main/java/com/example/algoproject/contain/service/ContainService.java
+++ b/src/main/java/com/example/algoproject/contain/service/ContainService.java
@@ -1,0 +1,45 @@
+package com.example.algoproject.contain.service;
+
+import com.example.algoproject.contain.domain.Contain;
+import com.example.algoproject.contain.repository.ContainRepository;
+import com.example.algoproject.problem.domain.Problem;
+import com.example.algoproject.session.domain.Session;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ContainService {
+
+    private final ContainRepository containRepository;
+
+    @Transactional
+    public void save(Contain contain) {
+        containRepository.save(contain);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Contain> findBySession(Session session) {
+        return containRepository.findBySession(session);
+    }
+
+    @Transactional(readOnly = true)
+    public Contain findBySessionAndProblem(Session session, Problem problem) {
+        return containRepository.findBySessionAndProblem(session, problem);
+    }
+
+    @Transactional
+    public void deleteAllBySession(Session session) {
+        containRepository.deleteAllBySession(session);
+    }
+
+    @Transactional
+    public void deleteBySessionAndProblem(Session session, Problem problem) {
+        containRepository.deleteBySessionAndProblem(session, problem);
+    }
+}

--- a/src/main/java/com/example/algoproject/github/service/GithubService.java
+++ b/src/main/java/com/example/algoproject/github/service/GithubService.java
@@ -190,7 +190,7 @@ public class GithubService {
         }
     }
 
-    public void commitFileResponse(String sha, User leader, User user, String content, String fileName, String path, String repoName, String commitMessage) throws IOException {
+    public void commitFileResponse(String sha, User leader, User user, String content, String fileName, String path, String repoName, String commitMessage){
         HttpHeaders headers = makeHeader(user);
         CommitFileRequest request = new CommitFileRequest();
         request.setMessage(commitMessage);

--- a/src/main/java/com/example/algoproject/problem/controller/ProblemController.java
+++ b/src/main/java/com/example/algoproject/problem/controller/ProblemController.java
@@ -2,6 +2,7 @@ package com.example.algoproject.problem.controller;
 
 import com.example.algoproject.errors.response.*;
 import com.example.algoproject.problem.dto.request.AddProblem;
+import com.example.algoproject.problem.dto.request.DeleteProblem;
 import com.example.algoproject.problem.service.ProblemService;
 import com.example.algoproject.user.dto.CustomUserDetailsVO;
 import com.example.algoproject.util.Auth;
@@ -22,7 +23,7 @@ public class ProblemController {
     private final ProblemService problemService;
 
     @Auth(role = LEADER)
-    @Operation(summary="문제 추가(팀장만 가능)", description="세션 ID, 문제의 번호, 이름, 플랫폼을 받아 문제의 정보 반환")
+    @Operation(summary="문제 추가(팀장만 가능)", description="세션 ID, 문제의 ID를 받아 문제의 정보 반환")
     @PostMapping()
     public CommonResponse problemAdd(@AuthenticationPrincipal @RequestBody @Valid AddProblem request) {
         return problemService.create(request);
@@ -38,7 +39,8 @@ public class ProblemController {
     @Auth(role = LEADER)
     @Operation(summary = "문제 삭제(팀장만 가능)", description = "문제 ID로 문제를 삭제후 성공 여부만 반환")
     @DeleteMapping("/{id}")
-    public CommonResponse problemRemove(@AuthenticationPrincipal CustomUserDetailsVO cudVO, @PathVariable Long id) {
-        return problemService.delete(cudVO, id);
+    public CommonResponse problemRemove(@AuthenticationPrincipal CustomUserDetailsVO cudVO,
+                                        @PathVariable Long id, @RequestBody @Valid DeleteProblem request) {
+        return problemService.delete(cudVO, id, request);
     }
 }

--- a/src/main/java/com/example/algoproject/problem/domain/Problem.java
+++ b/src/main/java/com/example/algoproject/problem/domain/Problem.java
@@ -1,15 +1,9 @@
 package com.example.algoproject.problem.domain;
 
-import com.example.algoproject.problem.dto.request.AddProblem;
-import com.example.algoproject.session.domain.Session;
-import com.example.algoproject.solution.domain.Solution;
-import com.example.algoproject.study.domain.Study;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -25,32 +19,17 @@ public class Problem {
 
     private String name;
 
+    private int level;
+
     private String url;
 
     private Platform platform;
 
-    @ManyToOne
-    @JoinColumn(name = "session_id")
-    private Session session;
-
-    @OneToMany(
-            mappedBy = "problem",
-            cascade = {CascadeType.ALL},
-            orphanRemoval = true
-    )
-    private List<Solution> solutions = new ArrayList<>();
-
-    public Problem(AddProblem request) {
-        this.number = request.getNumber();
-        this.name = request.getName();
-        this.platform = Platform.valueOf(request.getPlatform());
-        this.url = this.platform.getUrl() + request.getNumber();
-    }
-
-    public void setSession(Session session) {
-        this.session = session;
-
-        if(!session.getProblems().contains(this))
-            session.getProblems().add(this);
+    public Problem(String number, String name, int level, String platform) {
+        this.number = number;
+        this.name = name;
+        this.level = level;
+        this.platform = Platform.valueOf(platform);
+        this.url = this.platform.getUrl() + number;
     }
 }

--- a/src/main/java/com/example/algoproject/problem/dto/request/DeleteProblem.java
+++ b/src/main/java/com/example/algoproject/problem/dto/request/DeleteProblem.java
@@ -5,11 +5,9 @@ import lombok.Data;
 import javax.validation.constraints.NotNull;
 
 @Data
-public class AddProblem {
+public class DeleteProblem {
 
     @NotNull(message = "세션 아이디는 필수 입니다.")
     private Long sessionId;
 
-    @NotNull(message = "문제 아이디는 필수 입력 값 입니다.")
-    private Long problemId;
 }

--- a/src/main/java/com/example/algoproject/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/example/algoproject/problem/repository/ProblemRepository.java
@@ -9,5 +9,4 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
-    List<Problem> findBySession(Session session);
 }

--- a/src/main/java/com/example/algoproject/problem/service/ProblemService.java
+++ b/src/main/java/com/example/algoproject/problem/service/ProblemService.java
@@ -1,18 +1,20 @@
 package com.example.algoproject.problem.service;
 
+import com.example.algoproject.contain.domain.Contain;
+import com.example.algoproject.contain.service.ContainService;
 import com.example.algoproject.errors.exception.notfound.NotExistProblemException;
 import com.example.algoproject.errors.response.CommonResponse;
 import com.example.algoproject.errors.response.ResponseService;
 import com.example.algoproject.github.service.GithubService;
 import com.example.algoproject.problem.domain.Problem;
 import com.example.algoproject.problem.dto.request.AddProblem;
+import com.example.algoproject.problem.dto.request.DeleteProblem;
 import com.example.algoproject.problem.dto.response.ProblemInfo;
 import com.example.algoproject.problem.repository.ProblemRepository;
 import com.example.algoproject.session.domain.Session;
 import com.example.algoproject.session.service.SessionService;
 import com.example.algoproject.solution.domain.Solution;
 import com.example.algoproject.study.domain.Study;
-import com.example.algoproject.study.service.StudyService;
 import com.example.algoproject.user.domain.User;
 import com.example.algoproject.user.dto.CustomUserDetailsVO;
 import com.example.algoproject.user.service.UserService;
@@ -21,8 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -33,44 +33,43 @@ public class ProblemService {
     private final ResponseService responseService;
     private final SessionService sessionService;
     private final UserService userService;
-    private final StudyService studyService;
+    private final ContainService containService;
     private final GithubService githubService;
 
     @Transactional
     public CommonResponse create(AddProblem request) {
 
         Session session = sessionService.findById(request.getSessionId());
-        Problem problem = new Problem(request);
+        Problem problem = findById(request.getProblemId());
 
-        problem.setSession(session);
-        session.addProblem(problem);
-        problemRepository.save(problem);
+        containService.save(new Contain(session, problem));
 
         return responseService.getSingleResponse(new ProblemInfo(problem));
     }
 
     @Transactional(readOnly = true)
     public CommonResponse list(Long sessionId) {
-        return responseService.getListResponse(getProblemInfos(
-                problemRepository.findBySession(sessionService.findById(sessionId))));
+
+        return responseService.getListResponse(
+                containService.findBySession(
+                        sessionService.findById(sessionId)).stream()
+                        .map(Contain::getProblem)
+                        .map(this::getProblemInfo)
+                        .toList());
     }
 
     @Transactional
-    public CommonResponse delete(CustomUserDetailsVO cudVO, Long id) {
+    public CommonResponse delete(CustomUserDetailsVO cudVO, Long id, DeleteProblem request) {
 
         User user = userService.findById(cudVO.getUsername());
         Problem problem = findById(id);
-        Study study = studyService.findById(problem.getSession().getStudy().getId());
+        Session session = sessionService.findById(request.getSessionId());
+        Study study = session.getStudy();
 
-        // 관련 솔루션 삭제
-        for (Solution solution: problem.getSolutions()) {
-            String codeSHA = githubService.checkFileResponse(user, user, solution.getCodePath(), study.getRepositoryName());
-            String readMeSHA = githubService.checkFileResponse(user, user, solution.getReadMePath(), study.getRepositoryName());
+        containService.findBySessionAndProblem(session, problem).getSolutions()
+                .forEach(solution -> removeGithubFile(user,study,solution));
 
-            githubService.deleteFileResponse(codeSHA, user, user, study.getRepositoryName(), solution.getCodePath(), "delete");
-            githubService.deleteFileResponse(readMeSHA, user, user, study.getRepositoryName(), solution.getReadMePath(), "delete");
-        }
-        problemRepository.delete(problem);
+        containService.deleteBySessionAndProblem(session, problem);
 
         return responseService.getSuccessResponse();
     }
@@ -84,10 +83,15 @@ public class ProblemService {
     // private
     //
 
-    private List<ProblemInfo> getProblemInfos(List<Problem> problems) {
-        List<ProblemInfo> infos = new ArrayList<>();
-        for (Problem problem : problems)
-            infos.add(new ProblemInfo(problem));
-        return infos;
+    private ProblemInfo getProblemInfo(Problem problem) {
+        return new ProblemInfo(problem);
+    }
+
+    private void removeGithubFile(User user, Study study, Solution solution) {
+        String codeSHA = githubService.checkFileResponse(user, user, solution.getCodePath(), study.getRepositoryName());
+        String readMeSHA = githubService.checkFileResponse(user, user, solution.getReadMePath(), study.getRepositoryName());
+
+        githubService.deleteFileResponse(codeSHA, user, user, study.getRepositoryName(), solution.getCodePath(), "delete");
+        githubService.deleteFileResponse(readMeSHA, user, user, study.getRepositoryName(), solution.getReadMePath(), "delete");
     }
 }

--- a/src/main/java/com/example/algoproject/session/domain/Session.java
+++ b/src/main/java/com/example/algoproject/session/domain/Session.java
@@ -32,24 +32,10 @@ public class Session {
     @JoinColumn(name = "study_id")
     private Study study;
 
-    @OneToMany(
-            mappedBy = "session",
-            cascade = {CascadeType.ALL},
-            orphanRemoval = true
-    )
-    private List<Problem> problems = new ArrayList<>();
-
     public Session(CreateSession request) {
         this.name = request.getName();
         this.start = request.getStart();
         this.end = request.getEnd();
-    }
-
-    public void addProblem(Problem problem) {
-        this.problems.add(problem);
-
-        if(problem.getSession() != this)
-            problem.setSession(this);
     }
 
     public void update(UpdateSession request) {

--- a/src/main/java/com/example/algoproject/solution/controller/SolutionController.java
+++ b/src/main/java/com/example/algoproject/solution/controller/SolutionController.java
@@ -2,6 +2,7 @@ package com.example.algoproject.solution.controller;
 
 import com.example.algoproject.errors.response.CommonResponse;
 import com.example.algoproject.solution.dto.request.AddSolution;
+import com.example.algoproject.solution.dto.request.ListSolution;
 import com.example.algoproject.solution.dto.request.UpdateSolution;
 import com.example.algoproject.solution.service.SolutionService;
 import com.example.algoproject.user.dto.CustomUserDetailsVO;
@@ -11,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static com.example.algoproject.util.Auth.Role.*;
@@ -24,9 +24,9 @@ public class SolutionController {
     private final SolutionService solutionService;
 
     @Auth(role = MEMBER)
-    @Operation(summary="솔루션 생성", description="문제ID, code, readme, language를 받아 생성하고 솔루션의 정보를 반환")
+    @Operation(summary="솔루션 생성", description="문제ID, 세션ID, code, readme, language를 받아 생성하고 솔루션의 정보를 반환")
     @PostMapping()
-    public CommonResponse solutionAdd(@AuthenticationPrincipal CustomUserDetailsVO cudVO, @RequestBody AddSolution solution) throws IOException {
+    public CommonResponse solutionAdd(@AuthenticationPrincipal CustomUserDetailsVO cudVO, @RequestBody AddSolution solution) {
         return solutionService.create(cudVO, solution);
     }
 
@@ -39,15 +39,15 @@ public class SolutionController {
 
     @Auth(role = MEMBER)
     @Operation(summary="팀원들의 솔루션 등록 여부 조회", description="해당 문제를 풀어야하는 팀원들의 목록과 솔루션 등록 여부 list를 반환.")
-    @GetMapping("/list/{problemId}")
-    public CommonResponse solutionList(@AuthenticationPrincipal @PathVariable("problemId") Long problemId) {
-        return solutionService.list(problemId);
+    @GetMapping("/list")
+    public CommonResponse solutionList(@AuthenticationPrincipal ListSolution request) {
+        return solutionService.list(request);
     }
 
     @Auth(role = MEMBER)
     @Operation(summary="솔루션 업데이트", description="솔루션 수정 후 솔루션의 정보를 반환")
     @PutMapping(value="/{id}")
-    public CommonResponse update(@AuthenticationPrincipal CustomUserDetailsVO cudVO, @RequestBody UpdateSolution solution, @PathVariable("id") Long id) throws IOException {
+    public CommonResponse update(@AuthenticationPrincipal CustomUserDetailsVO cudVO, @RequestBody UpdateSolution solution, @PathVariable("id") Long id){
         return solutionService.update(cudVO, id, solution);
     }
 

--- a/src/main/java/com/example/algoproject/solution/controller/SolutionController.java
+++ b/src/main/java/com/example/algoproject/solution/controller/SolutionController.java
@@ -40,7 +40,7 @@ public class SolutionController {
     @Auth(role = MEMBER)
     @Operation(summary="팀원들의 솔루션 등록 여부 조회", description="해당 문제를 풀어야하는 팀원들의 목록과 솔루션 등록 여부 list를 반환.")
     @GetMapping("/list")
-    public CommonResponse solutionList(@AuthenticationPrincipal ListSolution request) {
+    public CommonResponse solutionList(@AuthenticationPrincipal @RequestBody ListSolution request) {
         return solutionService.list(request);
     }
 

--- a/src/main/java/com/example/algoproject/solution/domain/Solution.java
+++ b/src/main/java/com/example/algoproject/solution/domain/Solution.java
@@ -1,7 +1,7 @@
 package com.example.algoproject.solution.domain;
 
+import com.example.algoproject.contain.domain.Contain;
 import com.example.algoproject.review.domain.Review;
-import com.example.algoproject.problem.domain.Problem;
 import com.example.algoproject.user.domain.User;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -41,8 +41,8 @@ public class Solution {
     private User user;
 
     @ManyToOne
-    @JoinColumn(name = "problem_id")
-    private Problem problem;
+    @JoinColumn(name = "contain_id")
+    private Contain contain;
 
     @OneToMany(
             mappedBy = "solution",
@@ -51,9 +51,9 @@ public class Solution {
     )
     private List<Review> reviews = new ArrayList<>();
 
-    public Solution(User user, Problem problem, String code, String readMe, Timestamp date, String language, String codePath, String readMePath) {
+    public Solution(User user, Contain contain, String code, String readMe, Timestamp date, String language, String codePath, String readMePath) {
         this.user = user;
-        this.problem = problem;
+        this.contain = contain;
         this.code = code;
         this.readMe = readMe;
         this.date = date;
@@ -68,10 +68,10 @@ public class Solution {
             review.setSolution(this);
     }
 
-    public void setProblem(Problem problem) {
-        this.problem = problem;
+    public void setContain(Contain contain) {
+        this.contain = contain;
 
-        if(!problem.getSolutions().contains(this))
-            problem.getSolutions().add(this);
+        if(!contain.getSolutions().contains(this))
+            contain.getSolutions().add(this);
     }
 }

--- a/src/main/java/com/example/algoproject/solution/dto/request/AddSolution.java
+++ b/src/main/java/com/example/algoproject/solution/dto/request/AddSolution.java
@@ -13,6 +13,9 @@ public class AddSolution {
     private Long problemId;
 
     @NotNull
+    private Long sessionId;
+
+    @NotNull
     @Lob
     private String code;
 

--- a/src/main/java/com/example/algoproject/solution/dto/request/ListSolution.java
+++ b/src/main/java/com/example/algoproject/solution/dto/request/ListSolution.java
@@ -1,0 +1,15 @@
+package com.example.algoproject.solution.dto.request;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ListSolution {
+
+    @NotNull
+    private Long problemId;
+
+    @NotNull
+    private Long sessionId;
+}

--- a/src/main/java/com/example/algoproject/solution/dto/request/UpdateSolution.java
+++ b/src/main/java/com/example/algoproject/solution/dto/request/UpdateSolution.java
@@ -12,6 +12,9 @@ public class UpdateSolution {
     private Long problemId;
 
     @NotNull
+    private Long sessionId;
+
+    @NotNull
     private String userId;
 
     @NotNull

--- a/src/main/java/com/example/algoproject/solution/repository/SolutionRepository.java
+++ b/src/main/java/com/example/algoproject/solution/repository/SolutionRepository.java
@@ -1,5 +1,6 @@
 package com.example.algoproject.solution.repository;
 
+import com.example.algoproject.contain.domain.Contain;
 import com.example.algoproject.problem.domain.Problem;
 import com.example.algoproject.solution.domain.Solution;
 import com.example.algoproject.user.domain.User;
@@ -12,8 +13,9 @@ import java.util.Optional;
 @Repository
 public interface SolutionRepository extends JpaRepository<Solution, Long> {
 
-    List<Solution> findByProblem(Problem problem);
-    Optional<Solution> findByProblemAndUser(Problem problem, User user);
     Optional<Solution> findByCodePath(String codePath);
+
     Optional<Solution> findByReadMePath(String readMePath);
+
+    Optional<Solution> findByUserAndContain(User user, Contain contain);
 }


### PR DESCRIPTION
- 세션과 1대다의 관계를 사이에 새로운 연관테이블(CONTAIN)을 추가해 다대다의 관계로 변경
- 해당 연관 테이블이 솔루션과 1대다의 관계를 가지도록 변경
- 문제와 태그의 다대다 관계를 연관테이블(HAVE)를 추가해 생성
- 원래 문제와 연관관계를 가지던 솔루션 테이블을 CONTAIN 테이블과 일대다 관계를 가지도록 변경
- Solved.ac의 API를 이용해 전체 문제를 가져와 DB에 저장하는 method 추가